### PR TITLE
bump node version to 20, use pnpm instead of npm

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:18
+FROM node:20
 
 # Set the working directory
 WORKDIR /
@@ -7,14 +7,17 @@ WORKDIR /
 # Copy package.json and package-lock.json
 COPY package*.json .
 
+# Install pnpm
+RUN npm install -g pnpm
+
 # Install dependencies
-RUN npm install --legacy-peer-deps
+RUN pnpm install
 
 # Copy the rest of the source code
 COPY . .
 
 # Build the TypeScript project
-RUN npm run build
+RUN pnpm run build
 
 
 # Specify the command to run the built project


### PR DESCRIPTION
Closes #21
The issue is not yet clear but the cause of it was the use of the `legacy-peer-deps` flag when running npm install. Moving to pnpm for dependency installation and building seems to fix the issue.